### PR TITLE
Allow passing of custom sleep implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - "3.3"
+  - "2.7"
+  - "2.6"
+script: python -m doctest -v src/tailer/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
 from distutils.core import setup
 
+
 def main():
 
     setup(
-        name = 'tailer',
+        name='tailer',
         packages=['tailer'],
-        package_dir = {'':'src'},
-        version = open('VERSION.txt').read().strip(),
+        package_dir={'': 'src'},
+        version=open('VERSION.txt').read().strip(),
         author='Mike Thornton',
         author_email='six8@devdetails.com',
         url='http://github.com/six8/pytailer',
-        download_url='http://github.com/six8/pytailer',        
+        download_url='http://github.com/six8/pytailer',
         license='MIT',
         keywords=['tail', 'head'],
         description='Python tail is a simple implementation of GNU tail and head.',
-        classifiers = [
+        classifiers=[
             "Programming Language :: Python",
             "Development Status :: 3 - Alpha",
             "Environment :: Console",
@@ -30,11 +31,11 @@ def main():
             "Topic :: System :: Systems Administration",
         ],
         long_description=open('README.rst').read(),
-        entry_points = {
+        entry_points={
             'console_scripts': [
                 'pytail = tailer:main',
             ],
-        },        
+        },
     )
 
 if __name__ == '__main__':

--- a/src/tailer/__init__.py
+++ b/src/tailer/__init__.py
@@ -5,7 +5,9 @@ import time
 if sys.version_info < (3,):
     range = xrange
 
+
 class Tailer(object):
+
     """\
     Implements tailing and heading functionality like GNU tail and head
     commands.
@@ -56,7 +58,7 @@ class Tailer(object):
             # The first charachter is a line terminator, don't count this one
             start += 1
 
-        while bytes_read > 0:          
+        while bytes_read > 0:
             # Scan forwards, counting the newlines in this bufferfull
             i = start
             while i < bytes_read:
@@ -98,7 +100,7 @@ class Tailer(object):
                 # found crlf
                 bytes_read -= 1
 
-        while bytes_read > 0:          
+        while bytes_read > 0:
             # Scan backward, counting the newlines in this bufferfull
             i = bytes_read - 1
             while i >= 0:
@@ -118,7 +120,7 @@ class Tailer(object):
             bytes_read, read_str = self.read(self.read_size)
 
         return None
-  
+
     def tail(self, lines=10):
         """\
         Return the last lines of the file.
@@ -135,7 +137,7 @@ class Tailer(object):
             return self.splitlines(data)
         else:
             return []
-               
+
     def head(self, lines=10):
         """\
         Return the top lines of the file.
@@ -145,9 +147,9 @@ class Tailer(object):
         for i in range(lines):
             if not self.seek_line_forward():
                 break
-    
+
         end_pos = self.file.tell()
-        
+
         self.seek(0)
         data = self.file.read(end_pos - 1)
 
@@ -162,12 +164,12 @@ class Tailer(object):
 
         Based on: http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/157035
         """
-        trailing = True       
-        
+        trailing = True
+
         while 1:
             where = self.file.tell()
             line = self.file.readline()
-            if line:    
+            if line:
                 if trailing and line in self.line_terminators:
                     # This is just the line terminator added to the end of the file
                     # before a new line, ignore.
@@ -193,6 +195,7 @@ class Tailer(object):
     def close(self):
         self.file.close()
 
+
 def tail(file, lines=10):
     """\
     Return the last lines of the file.
@@ -206,6 +209,7 @@ def tail(file, lines=10):
     """
     return Tailer(file).tail(lines)
 
+
 def head(file, lines=10):
     """\
     Return the top lines of the file.
@@ -218,6 +222,7 @@ def head(file, lines=10):
     ['Line 1', 'Line 2', 'Line 3']
     """
     return Tailer(file).head(lines)
+
 
 def follow(file, delay=1.0, sleeper=None):
     """\
@@ -245,9 +250,11 @@ def follow(file, delay=1.0, sleeper=None):
     """
     return Tailer(file, end=True, sleeper=sleeper).follow(delay)
 
+
 def _test():
     import doctest
     doctest.testmod()
+
 
 def _main(filepath, options):
     tailer = Tailer(open(filepath, 'rb'))
@@ -262,7 +269,7 @@ def _main(filepath, options):
                     lines = tailer.head(options.lines)
                 else:
                     lines = tailer.tail(options.lines)
-        
+
                 for line in lines:
                     print(line)
             elif options.follow:
@@ -277,6 +284,7 @@ def _main(filepath, options):
             pass
     finally:
         tailer.close()
+
 
 def main():
     from optparse import OptionParser

--- a/src/tailer/__init__.py
+++ b/src/tailer/__init__.py
@@ -200,10 +200,13 @@ def tail(file, lines=10):
     """\
     Return the last lines of the file.
 
-    >>> import StringIO
-    >>> f = StringIO.StringIO()
+    >>> try:
+    ...     import StringIO as stringio
+    ... except ImportError:
+    ...    import io as stringio
+    >>> f = stringio.StringIO()
     >>> for i in range(11):
-    ...     f.write('Line %d\\n' % (i + 1))
+    ...     x = f.write('Line %d\\n' % (i + 1))
     >>> tail(f, 3)
     ['Line 9', 'Line 10', 'Line 11']
     """
@@ -214,10 +217,13 @@ def head(file, lines=10):
     """\
     Return the top lines of the file.
 
-    >>> import StringIO
-    >>> f = StringIO.StringIO()
+    >>> try:
+    ...     import StringIO as stringio
+    ... except ImportError:
+    ...    import io as stringio
+    >>> f = stringio.StringIO()
     >>> for i in range(11):
-    ...     f.write('Line %d\\n' % (i + 1))
+    ...     x = f.write('Line %d\\n' % (i + 1))
     >>> head(f, 3)
     ['Line 1', 'Line 2', 'Line 3']
     """
@@ -229,20 +235,22 @@ def follow(file, delay=1.0, sleeper=None):
     Iterator generator that returns lines as data is added to the file.
 
     >>> import os
-    >>> f = file('test_follow.txt', 'w')
-    >>> fo = file('test_follow.txt', 'r')
+    >>> f = open('test_follow.txt', 'w')
+    >>> fo = open('test_follow.txt', 'r')
     >>> generator = follow(fo)
-    >>> f.write('Line 1\\n')
+    >>> x = f.write('Line 1\\n')
     >>> f.flush()
-    >>> generator.next()
+    >>> next(generator)
     'Line 1'
-    >>> f.write('Line 2\\n')
+    >>> x = f.write('Line 2\\n')
     >>> f.flush()
-    >>> generator.next()
+    >>> next(generator)
     'Line 2'
-    >>> def sleeper(delay): f.write('Line 3\\n'); f.flush()
+    >>> def sleeper(delay):
+    ...     f.write('Line 3\\n')
+    ...     f.flush()
     >>> generator = follow(fo, sleeper=sleeper)
-    >>> generator.next()
+    >>> next(generator)
     'Line 3'
     >>> f.close()
     >>> fo.close()


### PR DESCRIPTION
Either by passing a callable as the `sleeper` argument, or by inheriting
from `Tailer` and overwriting the `sleeper` method, one may provide
a custom implementation of the sleep call.

This may be useful in situations where additional abort logic is required,
like in a thread that should not block on a file that's not written to.