### PR TITLE
Raise an error if the file is erased while following

### DIFF
--- a/src/tailer/__init__.py
+++ b/src/tailer/__init__.py
@@ -159,6 +159,10 @@ class Tailer(object):
         trailing = True
 
         while 1:
+
+	    if not os.path.exists(os.path.realpath(self.file.name)): #Check if the file still exists
+                raise IOError	
+	 
             where = self.file.tell()
             line = self.file.readline()
             if line:


### PR DESCRIPTION
Actually if the file is deleted while pytailer is listening it dont raise any error and not restart reading in case the file is created again. So the thread is completely blocked.